### PR TITLE
✨ Merge additional TOML files

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -239,6 +239,87 @@ The default list excludes:
    written to the output file, potentially creating circular dependencies or
    duplicate configurations.
 
+.. _`config_merge_toml_files`:
+
+needscfg_merge_toml_files
+-------------------------
+
+**Type:** ``list[str]``
+
+**Default:** ``[]`` (empty list)
+
+Specifies a list of TOML file paths to shallow-merge into the final output configuration.
+This allows you to include additional configuration from external TOML files into the
+generated ``ubproject.toml``.
+
+The paths support the same template variables as :ref:`config_outpath`:
+
+- ``${outdir}`` - Replaced with the Sphinx output directory (build directory)
+- ``${srcdir}`` - Replaced with the Sphinx source directory
+
+Relative paths are interpreted relative to the configuration directory (where ``conf.py`` is located).
+
+**Merge behavior:**
+
+- Files are processed in the order they appear in the list
+- Each file is shallow-merged (top-level keys only) into the configuration
+- If a TOML file has a ``[needs]`` table, only that table is merged
+- If no ``[needs]`` table exists, the entire file content is merged
+- Values from merged files **override** values from the Sphinx configuration
+- Later files in the list override earlier files
+
+**Use cases:**
+
+- Add project-specific metadata not available in Sphinx config
+- Include version information from separate TOML files
+- Merge team-wide configuration standards
+- Add deployment-specific settings
+
+**Examples:**
+
+.. code-block:: python
+
+   # Merge a single additional configuration file
+   needscfg_merge_toml_files = ["additional_config.toml"]
+
+   # Merge multiple files (processed in order)
+   needscfg_merge_toml_files = [
+       "${srcdir}/team_defaults.toml",
+       "project_overrides.toml",
+   ]
+
+   # Use build output directory
+   needscfg_merge_toml_files = ["${outdir}/generated_metadata.toml"]
+
+**Example TOML file with needs table:**
+
+.. code-block:: toml
+
+   # additional_config.toml
+   [needs]
+   project_version = "1.2.3"
+   build_date = "2025-10-28"
+
+**Example TOML file without needs table:**
+
+.. code-block:: toml
+
+   # additional_config.toml
+   project_version = "1.2.3"
+   build_date = "2025-10-28"
+
+Both formats work - if a ``[needs]`` table exists, only its contents are merged.
+
+.. note::
+
+   If a merge file doesn't exist, a warning is emitted but the build continues.
+   Failed file loads (e.g., invalid TOML syntax) also emit warnings without stopping the build.
+
+.. tip::
+
+   Use this feature to separate dynamic configuration (like version numbers or build metadata)
+   from static Sphinx-Needs configuration in ``conf.py``.
+
 Examples
 --------
 

--- a/needs_config_writer/logging.py
+++ b/needs_config_writer/logging.py
@@ -12,7 +12,12 @@ def get_logger(name: str) -> SphinxLoggerAdapter:
     return logging.getLogger(name)
 
 
-WarningSubTypes = Literal["path_conversion", "unsupported_type", "content_diff"]
+WarningSubTypes = Literal[
+    "path_conversion",
+    "unsupported_type",
+    "content_diff",
+    "merge_failed",
+]
 
 
 def log_warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,12 @@ classifiers = [
   "Topic :: Utilities",
   "Framework :: Sphinx :: Extension",
 ]
-dependencies = ["sphinx>=4.0", "sphinx-needs>4.2.0", "tomli-w>=1.2.0"]
+dependencies = [
+  "sphinx>=4.0",
+  "sphinx-needs>4.2.0",
+  "tomli>=2.3.0",
+  "tomli-w>=1.2.0",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,7 @@ dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-needs" },
+    { name = "tomli" },
     { name = "tomli-w" },
 ]
 
@@ -506,6 +507,7 @@ docs = [
 requires-dist = [
     { name = "sphinx", specifier = ">=4.0" },
     { name = "sphinx-needs", specifier = ">4.2.0" },
+    { name = "tomli", specifier = ">=2.3.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 


### PR DESCRIPTION
New config `needscfg_merge_toml_files` to specify a list of strings.
Those are paths to additional TOML files that are shallow-merged into the resulting config.
There are 2 shallow merges happening, one with the `needs` table and then after this
again on root level.